### PR TITLE
Sed fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Prerequisites:
 * An AWS account that can create and manage EKS clusters.
 * Terraform is used for provisioning the EKS cluster. Get it [here](https://www.terraform.io/downloads.html).
 * Kubectl for interacting with Kubernetes. Install a compatible version from [here](https://kubernetes.io/docs/tasks/tools/install-kubectl/#install-kubectl). Kubectl supports one release of version skew, and here we use Kubernetes 1.10, so you will need kubectl 1.10 or 1.11.
+* Ensure `AWS_SECRET_ACCESS_KEY, AWS_DEFAULT_REGION, AWS_ACCESS_KEY_ID` are all exported to the appropriate values
 
 Optional:
 * A license for Milpa. Get one for free [here](https://www.elotl.co/trial). If no license is set, Milpa will switch into Developer Edition mode, which limits the number of pods it will handle.

--- a/terraform/update-config.sh
+++ b/terraform/update-config.sh
@@ -11,7 +11,7 @@ fi
 export service_cidr="$service_cidr"
 
 # Get k8s version.
-export k8s_version=$(kubectl version --short | grep -i "Server" | sed -r 's/^Server Version: (v[0-9]+\.[0-9]+\.[0-9]+).*$/\1/g')
+export k8s_version=$(kubectl version --short | grep -i "Server" | sed -E 's/^Server Version: (v[0-9]+\.[0-9]+\.[0-9]+).*$/\1/g')
 
 # Export userdata template substitution variables.
 export node_nametag="${node_nametag}"


### PR DESCRIPTION
Fixes:
- Update readme to include the notes about exporting AWS specific variables in the "prerequisites" section
- Update sed to use `-E` (osx & linux) for extended regex rather than `-r` (linux)
